### PR TITLE
Indexer - Missing Tokens - Key (defaultAdmin)=(0x450cb53a7320cfa0de3321b51cfaa96d73664a63) is not present in table "in_process_artists

### DIFF
--- a/lib/processBlocks.js
+++ b/lib/processBlocks.js
@@ -17,8 +17,12 @@ async function processBlocks(network, start, end) {
     console.log("DECODED LOGS", decodedLogs);
     const block = await getBlock(network, decodedLogs[0].blockNumber);
     const supabaseUpsertData = mapLogsToSupabase(decodedLogs, block, network);
-    await upsertTokens(supabaseUpsertData);
+    
+    // Create artists first to avoid foreign key constraint violations
     await updateProfiles(decodedLogs);
+    // Then insert tokens that reference the artists
+    await upsertTokens(supabaseUpsertData);
+    
     console.log(`${network} - Would process batch of ${batch.length} events`);
   }
 }


### PR DESCRIPTION
A foreign key constraint violation occurred in the `in_process_artists` table, where token insertions failed due to references to non-existent artists.

The fix involved reordering operations within `lib/processBlocks.js`:
*   Previously, `upsertTokens` was called before `updateProfiles`. This led to tokens referencing artists that had not yet been created or updated in the database.
*   The order was reversed: `updateProfiles(decodedLogs)` is now executed before `upsertTokens(supabaseUpsertData)`.
*   This ensures artist records are present in the `in_process_artists` table before tokens referencing them are inserted, resolving the "Key not present in table" error.
*   Comments were added to clarify the dependency and the reasoning for the reordering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where tokens referencing artists could fail to save due to missing artist profiles, ensuring artist profiles are created or updated before related tokens are processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->