### PR TITLE
Sweetmantech/myc 2733 upserttokens deduplicate to prevent conflicts

### DIFF
--- a/lib/supabase/in_proces_tokens/upsertTokens.js
+++ b/lib/supabase/in_proces_tokens/upsertTokens.js
@@ -15,6 +15,15 @@ export async function upsertTokens(tokens) {
       )
   );
 
+  // Log deduplication info if there were duplicates
+  if (uniqueTokens.length < tokens.length) {
+    console.log(
+      `Deduplicated tokens: ${tokens.length} -> ${
+        uniqueTokens.length
+      } (removed ${tokens.length - uniqueTokens.length} duplicates)`
+    );
+  }
+
   const { data, error } = await supabase
     .from("in_process_tokens")
     .upsert(uniqueTokens, { onConflict: ["address", "chainId"] })

--- a/lib/supabase/in_proces_tokens/upsertTokens.js
+++ b/lib/supabase/in_proces_tokens/upsertTokens.js
@@ -6,9 +6,18 @@ import { supabase } from "../client.js";
  * @returns {Promise<Object>} - The upserted records or error.
  */
 export async function upsertTokens(tokens) {
+  // Remove duplicates based on conflict columns (address and chainId)
+  const uniqueTokens = tokens.filter(
+    (token, index, self) =>
+      index ===
+      self.findIndex(
+        (t) => t.address === token.address && t.chainId === token.chainId
+      )
+  );
+
   const { data, error } = await supabase
     .from("in_process_tokens")
-    .upsert(tokens, { onConflict: ["address", "chainId"] })
+    .upsert(uniqueTokens, { onConflict: ["address", "chainId"] })
     .select();
 
   if (error) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents duplicate tokens from appearing by deduplicating entries by address and chain.
  * Ensures cleaner token lists and more reliable syncing across the app.
  * Improves stability of token updates without changing any user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->